### PR TITLE
chore: sync env examples with application usage

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,69 +1,187 @@
-APP_NAME=Laravel
+# ------------------------------------------------------------------------------
+# Core Application Settings
+# ------------------------------------------------------------------------------
+APP_NAME=HospitalAPI
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
+APP_URL=http://localhost:8000
 APP_TIMEZONE=UTC
-APP_URL=http://localhost
-
-DATASTORE_DRIVER=eloquent
-DATASTORE_CONNECTION=sqlite
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US
+APP_PREVIOUS_KEYS=
 
 APP_MAINTENANCE_DRIVER=file
-# APP_MAINTENANCE_STORE=database
+APP_MAINTENANCE_STORE=database
 
-PHP_CLI_SERVER_WORKERS=4
+DATASTORE_DRIVER=eloquent
+DATASTORE_CONNECTION=sqlite
 
-BCRYPT_ROUNDS=12
+# ------------------------------------------------------------------------------
+# Authentication
+# ------------------------------------------------------------------------------
+AUTH_GUARD=web
+AUTH_MODEL=App\\Models\\User
+AUTH_PASSWORD_BROKER=users
+AUTH_PASSWORD_RESET_TOKEN_TABLE=password_reset_tokens
+AUTH_PASSWORD_TIMEOUT=10800
 
+# ------------------------------------------------------------------------------
+# Logging & Monitoring
+# ------------------------------------------------------------------------------
 LOG_CHANNEL=stack
 LOG_STACK=single
 LOG_DEPRECATIONS_CHANNEL=null
+LOG_DEPRECATIONS_TRACE=false
 LOG_LEVEL=debug
+LOG_DAILY_DAYS=14
+LOG_STDERR_FORMATTER=
+LOG_SYSLOG_FACILITY=LOG_USER
+LOG_SLACK_WEBHOOK_URL=
+LOG_SLACK_USERNAME=Laravel Log
+LOG_SLACK_EMOJI=:boom:
+LOG_PAPERTRAIL_HANDLER=Monolog\\Handler\\SyslogUdpHandler
+PAPERTRAIL_URL=
+PAPERTRAIL_PORT=
 
+# ------------------------------------------------------------------------------
+# Database Connections
+# ------------------------------------------------------------------------------
 DB_CONNECTION=sqlite
-# DB_HOST=127.0.0.1
-# DB_PORT=3306
-# DB_DATABASE=laravel
-# DB_USERNAME=root
-# DB_PASSWORD=
+DB_URL=
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=laravel
+DB_USERNAME=root
+DB_PASSWORD=
+DB_SOCKET=
+DB_CHARSET=utf8mb4
+DB_COLLATION=utf8mb4_unicode_ci
+DB_FOREIGN_KEYS=true
+MYSQL_ATTR_SSL_CA=
 
-SESSION_DRIVER=database
-SESSION_LIFETIME=120
-SESSION_ENCRYPT=false
-SESSION_PATH=/
-SESSION_DOMAIN=null
-
-BROADCAST_CONNECTION=log
-FILESYSTEM_DISK=local
-QUEUE_CONNECTION=database
-
+# ------------------------------------------------------------------------------
+# Cache Stores & Key-Value Backends
+# ------------------------------------------------------------------------------
 CACHE_STORE=database
 CACHE_PREFIX=
+DB_CACHE_CONNECTION=
+DB_CACHE_TABLE=cache
+DB_CACHE_LOCK_CONNECTION=
+DB_CACHE_LOCK_TABLE=cache_locks
 
+MEMCACHED_PERSISTENT_ID=
 MEMCACHED_HOST=127.0.0.1
+MEMCACHED_PORT=11211
+MEMCACHED_USERNAME=null
+MEMCACHED_PASSWORD=null
 
 REDIS_CLIENT=phpredis
+REDIS_URL=
 REDIS_HOST=127.0.0.1
-REDIS_PASSWORD=null
 REDIS_PORT=6379
+REDIS_USERNAME=null
+REDIS_PASSWORD=null
+REDIS_DB=0
+REDIS_PREFIX=
+REDIS_CLUSTER=redis
+REDIS_CACHE_CONNECTION=cache
+REDIS_CACHE_LOCK_CONNECTION=default
+REDIS_CACHE_DB=1
 
-MAIL_MAILER=log
-MAIL_SCHEME=null
-MAIL_HOST=127.0.0.1
-MAIL_PORT=2525
-MAIL_USERNAME=null
-MAIL_PASSWORD=null
-MAIL_FROM_ADDRESS="hello@example.com"
-MAIL_FROM_NAME="${APP_NAME}"
+DYNAMODB_CACHE_TABLE=cache
+DYNAMODB_ENDPOINT=
 
+# ------------------------------------------------------------------------------
+# Queue Processing
+# ------------------------------------------------------------------------------
+QUEUE_CONNECTION=database
+QUEUE_FAILED_DRIVER=database-uuids
+DB_QUEUE_CONNECTION=
+DB_QUEUE_TABLE=jobs
+DB_QUEUE=default
+DB_QUEUE_RETRY_AFTER=90
+REDIS_QUEUE_CONNECTION=default
+REDIS_QUEUE=default
+REDIS_QUEUE_RETRY_AFTER=90
+BEANSTALKD_QUEUE_HOST=localhost
+BEANSTALKD_QUEUE=default
+BEANSTALKD_QUEUE_RETRY_AFTER=90
+SQS_PREFIX=https://sqs.us-east-1.amazonaws.com/your-account-id
+SQS_QUEUE=default
+SQS_SUFFIX=
+
+# ------------------------------------------------------------------------------
+# Storage & File Systems
+# ------------------------------------------------------------------------------
+FILESYSTEM_DISK=local
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=us-east-1
 AWS_BUCKET=
+AWS_URL=
+AWS_ENDPOINT=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
-VITE_APP_NAME="${APP_NAME}"
+# ------------------------------------------------------------------------------
+# Mail Delivery
+# ------------------------------------------------------------------------------
+MAIL_MAILER=log
+MAIL_SCHEME=null
+MAIL_URL=
+MAIL_HOST=127.0.0.1
+MAIL_PORT=2525
+MAIL_USERNAME=null
+MAIL_PASSWORD=null
+MAIL_EHLO_DOMAIN=
+MAIL_SENDMAIL_PATH=/usr/sbin/sendmail -bs -i
+MAIL_LOG_CHANNEL=
+MAIL_FROM_ADDRESS="hello@example.com"
+MAIL_FROM_NAME="${APP_NAME}"
+POSTMARK_MESSAGE_STREAM_ID=
+POSTMARK_TOKEN=
+RESEND_KEY=
+SLACK_BOT_USER_OAUTH_TOKEN=
+SLACK_BOT_USER_DEFAULT_CHANNEL=
+
+# ------------------------------------------------------------------------------
+# Session Management
+# ------------------------------------------------------------------------------
+SESSION_DRIVER=database
+SESSION_CONNECTION=null
+SESSION_STORE=null
+SESSION_TABLE=sessions
+SESSION_LIFETIME=120
+SESSION_EXPIRE_ON_CLOSE=false
+SESSION_ENCRYPT=false
+SESSION_PATH=/
+SESSION_DOMAIN=null
+SESSION_SECURE_COOKIE=null
+SESSION_HTTP_ONLY=true
+SESSION_SAME_SITE=lax
+SESSION_PARTITIONED_COOKIE=false
+
+# ------------------------------------------------------------------------------
+# Form Submissions
+# ------------------------------------------------------------------------------
+FORM_UPLOAD_MAX_MB=5
+FORM_ALLOWED_MIME=application/pdf,image/jpeg,image/png
+FORM_ALLOWED_EXT=pdf,jpg,jpeg,png
+
+# ------------------------------------------------------------------------------
+# Express Bridge Service
+# ------------------------------------------------------------------------------
+PORT=4000
+JWT_SECRET=change-me-in-production
+TOKEN_EXPIRY=15m
+REFRESH_TOKEN_EXPIRY=7d
+# DB_URL is shared with the Laravel database section above
+CORS_ORIGINS=http://localhost:5173,http://localhost:4173
+HOSXP_HOST=localhost
+HOSXP_PORT=3306
+HOSXP_USER=
+HOSXP_PASSWORD=
+HOSXP_DATABASE=
+HOSXP_SSL=false

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,8 @@
-VITE_API_BASE_URL=https://api.hospital.local
+# Public API served by Laravel
+VITE_API_BASE_URL=http://localhost:8000
+
+# Public content endpoints (Express mock)
+VITE_PUBLIC_API=http://localhost:4000/api
+
+# Secure admin endpoints (Express mock)
+VITE_SECURE_API=http://localhost:4000/api


### PR DESCRIPTION
## Summary
- align `backend/.env.example` with the environment variables referenced throughout Laravel and the Express bridge, adding missing keys and pruning unused defaults
- document all required Vite variables in `frontend/.env.example` for the public and secure API endpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de785d10b8832bbe383406297ae6a7