### PR TITLE
Adjust CSRF cookie security for development environments

### DIFF
--- a/backend/express/src/middleware/csrf.js
+++ b/backend/express/src/middleware/csrf.js
@@ -1,11 +1,13 @@
 const csurf = require('csurf')
 
 // Configure CSRF middleware to use cookies suitable for HTTPS reverse proxy setups.
+const isProduction = process.env.NODE_ENV === 'production'
+
 const csrfProtection = csurf({
   cookie: {
     httpOnly: true,
-    sameSite: 'strict',
-    secure: true
+    sameSite: isProduction ? 'strict' : 'lax',
+    secure: isProduction
   }
 })
 


### PR DESCRIPTION
## Summary
- make the CSRF middleware detect production environments and only enforce secure cookies there
- relax SameSite behavior in development so local HTTP requests can fetch CSRF tokens successfully

## Testing
- npm test (backend/express)


------
https://chatgpt.com/codex/tasks/task_e_68df3819bd00832bbd47308c73f80dfc