### PR TITLE
Add frontend-backend integration audit tooling and reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ backend/simple-api/node_modules/
 frontend/.env.development
 frontend/node_modules/
 frontend/dist/
+tools/integration-check/dist/

--- a/docs/api.contract.json
+++ b/docs/api.contract.json
@@ -1,0 +1,687 @@
+{
+  "generatedAt": "2025-01-04T00:00:00Z",
+  "source": "docs/ROUTES.md",
+  "endpoints": [
+    {
+      "path": "/api/health",
+      "method": "GET",
+      "category": "public",
+      "headers": [],
+      "query": {},
+      "body": null,
+      "responses": {
+        "200": {
+          "shape": {
+            "data": {
+              "ok": "boolean",
+              "app": {
+                "name": "string",
+                "environment": "string",
+                "version": "string"
+              },
+              "services": {
+                "database": { "status": "string", "connection": "string" },
+                "queue": { "status": "string", "connection": "string" },
+                "storage": { "status": "string", "disk": "string" }
+              }
+            },
+            "meta": {
+              "request_id": "string",
+              "timestamp": "string"
+            }
+          }
+        }
+      },
+      "errors": {
+        "429": "standardRateLimit",
+        "500": "standardServerError"
+      }
+    },
+    {
+      "path": "/api/security/csrf-token",
+      "method": "GET",
+      "category": "public",
+      "headers": [],
+      "query": {},
+      "body": null,
+      "responses": {
+        "200": {
+          "shape": {
+            "data": {
+              "csrf_token": "string"
+            },
+            "meta": {
+              "request_id": "string"
+            }
+          }
+        }
+      },
+      "errors": {
+        "429": "standardRateLimit",
+        "500": "standardServerError"
+      }
+    },
+    {
+      "path": "/api/news",
+      "method": "GET",
+      "category": "public",
+      "headers": [],
+      "query": {
+        "page": { "type": "number", "required": false, "default": 1 },
+        "per_page": { "type": "number", "required": false, "default": 10, "max": 50 },
+        "sort": { "type": "string", "required": false, "enum": ["-published_at", "published_at"], "default": "-published_at" }
+      },
+      "body": null,
+      "responses": {
+        "200": {
+          "shape": {
+            "data": {
+              "news": [
+                {
+                  "id": "number",
+                  "title": "string",
+                  "body": "string",
+                  "published_at": "string"
+                }
+              ],
+              "pagination": {
+                "current_page": "number",
+                "per_page": "number",
+                "total": "number",
+                "last_page": "number"
+              }
+            },
+            "meta": {
+              "request_id": "string"
+            }
+          }
+        }
+      },
+      "errors": {
+        "400": "standardValidation",
+        "429": "standardRateLimit",
+        "500": "standardServerError"
+      }
+    },
+    {
+      "path": "/api/forms/medical-record-request",
+      "method": "POST",
+      "category": "public-form",
+      "headers": [
+        "Accept: application/json",
+        "X-CSRF-TOKEN",
+        "X-Requested-With: XMLHttpRequest"
+      ],
+      "body": {
+        "type": "multipart/form-data",
+        "fields": {
+          "full_name": { "type": "string", "required": true },
+          "hn": { "type": "string", "required": true },
+          "citizen_id": { "type": "string", "required": true },
+          "phone": { "type": "string", "required": true },
+          "email": { "type": "string", "required": false },
+          "address": { "type": "string", "required": true },
+          "reason": { "type": "string", "required": false },
+          "consent": { "type": "boolean", "required": true },
+          "idcard_file": {
+            "type": "file",
+            "required": false,
+            "constraints": {
+              "mime": "FORM_ALLOWED_MIME",
+              "ext": "FORM_ALLOWED_EXT",
+              "maxMb": "FORM_UPLOAD_MAX_MB"
+            }
+          }
+        }
+      },
+      "responses": {
+        "201": {
+          "shape": {
+            "data": {
+              "id": "number",
+              "submitted_at": "string"
+            },
+            "meta": {
+              "request_id": "string"
+            }
+          }
+        }
+      },
+      "errors": {
+        "400": "standardValidation",
+        "419": "standardCsrf",
+        "429": "standardRateLimit",
+        "500": "standardServerError"
+      }
+    },
+    {
+      "path": "/api/forms/donation",
+      "method": "POST",
+      "category": "public-form",
+      "headers": [
+        "Accept: application/json",
+        "Content-Type: application/json",
+        "X-CSRF-TOKEN",
+        "X-Requested-With: XMLHttpRequest"
+      ],
+      "body": {
+        "type": "json",
+        "fields": {
+          "donor_name": { "type": "string", "required": true },
+          "amount": { "type": "number", "required": true, "min": 0.01 },
+          "channel": { "type": "string", "required": true, "enum": ["cash", "bank", "promptpay"] },
+          "phone": { "type": "string", "required": false },
+          "email": { "type": "string", "required": false },
+          "note": { "type": "string", "required": false }
+        }
+      },
+      "responses": {
+        "201": {
+          "shape": {
+            "data": {
+              "id": "number",
+              "reference_code": "string",
+              "submitted_at": "string"
+            },
+            "meta": {
+              "request_id": "string"
+            }
+          }
+        }
+      },
+      "errors": {
+        "400": "standardValidation",
+        "419": "standardCsrf",
+        "429": "standardRateLimit",
+        "500": "standardServerError"
+      }
+    },
+    {
+      "path": "/api/forms/satisfaction",
+      "method": "POST",
+      "category": "public-form",
+      "headers": [
+        "Accept: application/json",
+        "Content-Type: application/json",
+        "X-CSRF-TOKEN",
+        "X-Requested-With: XMLHttpRequest"
+      ],
+      "body": {
+        "type": "json",
+        "fields": {
+          "score_overall": { "type": "number", "required": true, "min": 1, "max": 5 },
+          "score_waittime": { "type": "number", "required": true, "min": 1, "max": 5 },
+          "score_staff": { "type": "number", "required": true, "min": 1, "max": 5 },
+          "comment": { "type": "string", "required": false },
+          "service_date": { "type": "string", "required": false, "format": "date" }
+        }
+      },
+      "responses": {
+        "201": {
+          "shape": {
+            "data": {
+              "id": "number",
+              "submitted_at": "string"
+            },
+            "meta": {
+              "request_id": "string"
+            }
+          }
+        }
+      },
+      "errors": {
+        "400": "standardValidation",
+        "419": "standardCsrf",
+        "429": "standardRateLimit",
+        "500": "standardServerError"
+      }
+    },
+    {
+      "path": "/api/programs/health-rider/apply",
+      "method": "POST",
+      "category": "public-form",
+      "headers": [
+        "Accept: application/json",
+        "Content-Type: application/json",
+        "X-CSRF-TOKEN",
+        "X-Requested-With: XMLHttpRequest"
+      ],
+      "body": {
+        "type": "json",
+        "fields": {
+          "full_name": { "type": "string", "required": true },
+          "hn": { "type": "string", "required": false },
+          "address": { "type": "string", "required": true },
+          "district": { "type": "string", "required": true },
+          "province": { "type": "string", "required": true },
+          "zipcode": { "type": "string", "required": true },
+          "phone": { "type": "string", "required": true },
+          "line_id": { "type": "string", "required": false },
+          "consent": { "type": "boolean", "required": true }
+        }
+      },
+      "responses": {
+        "201": {
+          "shape": {
+            "data": {
+              "id": "number",
+              "submitted_at": "string"
+            },
+            "meta": {
+              "request_id": "string"
+            }
+          }
+        }
+      },
+      "errors": {
+        "400": "standardValidation",
+        "419": "standardCsrf",
+        "429": "standardRateLimit",
+        "500": "standardServerError"
+      }
+    },
+    {
+      "path": "/api/auth/login",
+      "method": "POST",
+      "category": "auth",
+      "headers": [
+        "Accept: application/json",
+        "Content-Type: application/json",
+        "X-CSRF-TOKEN",
+        "X-Requested-With: XMLHttpRequest"
+      ],
+      "body": {
+        "type": "json",
+        "fields": {
+          "username": { "type": "string", "required": true },
+          "password": { "type": "string", "required": true }
+        }
+      },
+      "responses": {
+        "200": {
+          "shape": {
+            "data": {
+              "token": {
+                "access_token": "string",
+                "token_type": "string",
+                "abilities": ["string"]
+              },
+              "user": {
+                "id": "string",
+                "username": "string",
+                "name": "string",
+                "email": "string",
+                "role": "string",
+                "abilities": ["string"],
+                "last_login_at": "string"
+              }
+            },
+            "meta": {
+              "request_id": "string"
+            }
+          }
+        },
+        "401": {
+          "shape": {
+            "error": {
+              "message": "string"
+            },
+            "meta": {
+              "request_id": "string"
+            }
+          }
+        }
+      },
+      "errors": {
+        "429": "standardAuthThrottle",
+        "500": "standardServerError"
+      }
+    },
+    {
+      "path": "/api/auth/logout",
+      "method": "POST",
+      "category": "auth",
+      "headers": [
+        "Accept: application/json",
+        "Content-Type: application/json",
+        "Authorization: Bearer <token>",
+        "X-CSRF-TOKEN",
+        "X-Requested-With: XMLHttpRequest"
+      ],
+      "body": {
+        "type": "json",
+        "fields": {}
+      },
+      "responses": {
+        "200": {
+          "shape": {
+            "data": { "success": "boolean" },
+            "meta": { "request_id": "string" }
+          }
+        }
+      },
+      "errors": {
+        "401": "standardAuthFailed",
+        "419": "standardCsrf",
+        "429": "standardStaffRateLimit",
+        "500": "standardServerError"
+      }
+    },
+    {
+      "path": "/api/staff/me",
+      "method": "GET",
+      "category": "staff",
+      "headers": [
+        "Accept: application/json",
+        "Authorization: Bearer <token>"
+      ],
+      "query": {},
+      "body": null,
+      "responses": {
+        "200": {
+          "shape": {
+            "data": {
+              "id": "string",
+              "username": "string",
+              "name": "string",
+              "email": "string",
+              "role": "string",
+              "abilities": ["string"],
+              "last_login_at": "string"
+            },
+            "meta": {
+              "request_id": "string"
+            }
+          }
+        }
+      },
+      "errors": {
+        "401": "standardAuthFailed",
+        "429": "standardStaffRateLimit",
+        "500": "standardServerError"
+      }
+    },
+    {
+      "path": "/api/staff/news",
+      "method": "GET",
+      "category": "staff",
+      "headers": [
+        "Accept: application/json",
+        "Authorization: Bearer <token>"
+      ],
+      "query": {
+        "page": { "type": "number", "required": false },
+        "per_page": { "type": "number", "required": false, "max": 50 },
+        "sort": { "type": "string", "required": false, "default": "-published_at" }
+      },
+      "body": null,
+      "responses": {
+        "200": {
+          "shape": {
+            "data": {
+              "news": [
+                {
+                  "id": "number",
+                  "title": "string",
+                  "summary": "string",
+                  "body": "string",
+                  "published_at": "string",
+                  "created_at": "string",
+                  "updated_at": "string"
+                }
+              ],
+              "pagination": {
+                "current_page": "number",
+                "per_page": "number",
+                "total": "number",
+                "last_page": "number"
+              }
+            },
+            "meta": {
+              "request_id": "string"
+            }
+          }
+        }
+      },
+      "errors": {
+        "401": "standardAuthFailed",
+        "403": "standardUnauthorized",
+        "429": "standardStaffRateLimit",
+        "500": "standardServerError"
+      }
+    },
+    {
+      "path": "/api/staff/news",
+      "method": "POST",
+      "category": "staff",
+      "headers": [
+        "Accept: application/json",
+        "Content-Type: application/json",
+        "Authorization: Bearer <token>",
+        "X-CSRF-TOKEN",
+        "X-Requested-With: XMLHttpRequest"
+      ],
+      "body": {
+        "type": "json",
+        "fields": {
+          "title": { "type": "string", "required": true },
+          "body": { "type": "string", "required": false },
+          "published_at": { "type": "string", "required": false }
+        }
+      },
+      "responses": {
+        "201": {
+          "shape": {
+            "data": {
+              "id": "number",
+              "title": "string",
+              "summary": "string",
+              "body": "string",
+              "published_at": "string",
+              "created_at": "string",
+              "updated_at": "string"
+            },
+            "meta": {
+              "request_id": "string"
+            }
+          }
+        }
+      },
+      "errors": {
+        "400": "standardValidation",
+        "401": "standardAuthFailed",
+        "403": "standardUnauthorized",
+        "419": "standardCsrf",
+        "429": "standardStaffRateLimit",
+        "500": "standardServerError"
+      }
+    },
+    {
+      "path": "/api/staff/news/{id}",
+      "method": "PUT",
+      "category": "staff",
+      "headers": [
+        "Accept: application/json",
+        "Content-Type: application/json",
+        "Authorization: Bearer <token>",
+        "X-CSRF-TOKEN",
+        "X-Requested-With: XMLHttpRequest"
+      ],
+      "body": {
+        "type": "json",
+        "fields": {
+          "title": { "type": "string", "required": false },
+          "body": { "type": "string", "required": false },
+          "published_at": { "type": "string", "required": false }
+        }
+      },
+      "responses": {
+        "200": {
+          "shape": {
+            "data": {
+              "id": "number",
+              "title": "string",
+              "summary": "string",
+              "body": "string",
+              "published_at": "string",
+              "created_at": "string",
+              "updated_at": "string"
+            },
+            "meta": {
+              "request_id": "string"
+            }
+          }
+        },
+        "404": {
+          "shape": {
+            "error": {
+              "message": "string"
+            },
+            "meta": {
+              "request_id": "string"
+            }
+          }
+        }
+      },
+      "errors": {
+        "400": "standardValidation",
+        "401": "standardAuthFailed",
+        "403": "standardUnauthorized",
+        "419": "standardCsrf",
+        "429": "standardStaffRateLimit",
+        "500": "standardServerError"
+      }
+    },
+    {
+      "path": "/api/staff/news/{id}",
+      "method": "DELETE",
+      "category": "staff",
+      "headers": [
+        "Accept: application/json",
+        "Authorization: Bearer <token>",
+        "X-CSRF-TOKEN",
+        "X-Requested-With: XMLHttpRequest"
+      ],
+      "body": null,
+      "responses": {
+        "204": {
+          "shape": null,
+          "headers": {
+            "X-Request-Id": "string"
+          }
+        }
+      },
+      "errors": {
+        "401": "standardAuthFailed",
+        "403": "standardUnauthorized",
+        "419": "standardCsrf",
+        "429": "standardStaffRateLimit",
+        "500": "standardServerError"
+      }
+    }
+  ],
+  "errorCatalog": {
+    "standardValidation": {
+      "status": 400,
+      "shape": {
+        "error": {
+          "message": "The given data was invalid.",
+          "details": "object"
+        },
+        "meta": {
+          "request_id": "string"
+        }
+      }
+    },
+    "standardAuthFailed": {
+      "status": 401,
+      "shape": {
+        "error": {
+          "message": "Authentication failed."
+        },
+        "meta": {
+          "request_id": "string"
+        }
+      }
+    },
+    "standardUnauthorized": {
+      "status": 403,
+      "shape": {
+        "error": {
+          "message": "This action is unauthorized."
+        },
+        "meta": {
+          "request_id": "string"
+        }
+      }
+    },
+    "standardNotFound": {
+      "status": 404,
+      "shape": {
+        "error": {
+          "message": "News article not found."
+        },
+        "meta": {
+          "request_id": "string"
+        }
+      }
+    },
+    "standardCsrf": {
+      "status": 419,
+      "shape": {
+        "error": {
+          "message": "CSRF token mismatch."
+        },
+        "meta": {
+          "request_id": "string"
+        }
+      }
+    },
+    "standardRateLimit": {
+      "status": 429,
+      "shape": {
+        "error": {
+          "message": "Too many requests."
+        },
+        "meta": {
+          "request_id": "string"
+        }
+      }
+    },
+    "standardAuthThrottle": {
+      "status": 429,
+      "shape": {
+        "error": {
+          "message": "Too many requests."
+        },
+        "meta": {
+          "request_id": "string"
+        }
+      },
+      "notes": "Limiter auth-login"
+    },
+    "standardStaffRateLimit": {
+      "status": 429,
+      "shape": {
+        "error": {
+          "message": "Too many requests."
+        },
+        "meta": {
+          "request_id": "string"
+        }
+      },
+      "notes": "Limiter staff-api"
+    },
+    "standardServerError": {
+      "status": 500,
+      "shape": {
+        "error": {
+          "message": "Internal server error."
+        },
+        "meta": {
+          "request_id": "string"
+        }
+      }
+    }
+  }
+}

--- a/frontend/.env.local.sample
+++ b/frontend/.env.local.sample
@@ -1,0 +1,6 @@
+# ตัวอย่างค่า ENV สำหรับ frontend (ไม่ใช่ค่า production)
+VITE_APP_NAME=PPH Hospital Portal
+VITE_API_BASE_URL=http://localhost:8000
+VITE_PUBLIC_API=http://localhost:8000/api
+VITE_SECURE_API=http://localhost:8000/api
+# ตั้ง SANCTUM_STATEFUL_DOMAINS บน backend ให้ครอบคลุมโดเมน frontend ตาม docs/ENV.md

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,30 @@
+# Frontend Integration Notes
+
+## Environment variables
+
+สร้างไฟล์ `.env.local` ในโฟลเดอร์นี้โดยอ้างอิงจากตัวอย่างด้านล่าง (ไม่ต้องใส่ secret จริง):
+
+```
+VITE_APP_NAME=PPH Hospital Portal
+VITE_API_BASE_URL=http://localhost:8000
+VITE_PUBLIC_API=http://localhost:8000/api
+VITE_SECURE_API=http://localhost:8000/api
+```
+
+- `VITE_API_BASE_URL` ต้องไม่มี `/` ต่อท้าย ตามเอกสาร `docs/ENV.md`
+- `VITE_PUBLIC_API` และ `VITE_SECURE_API` ใช้เมื่อเชื่อมต่อ endpoint ภายนอก/พื้นที่ staff (สคริปต์ frontend ปัจจุบัน fallback เป็น `http://localhost:4000/api` หากไม่ตั้งค่า)
+
+## Integration check
+
+เรียกคำสั่งด้านล่างจากโฟลเดอร์ `frontend` เพื่อสร้างรายงาน diff และสรุป smoke test:
+
+```bash
+npm run integrate:check
+```
+
+คำสั่งนี้จะสร้าง/อัปเดตไฟล์รายงานในโฟลเดอร์ `reports/` ระดับ root ของโปรเจกต์ ได้แก่
+
+- `reports/route_contract_diff.md`
+- `reports/smoke_results.json`
+
+ตรวจสอบผลลัพธ์และดำเนินการแก้ไขตามรายการที่รายงาน

--- a/frontend/api.calls.json
+++ b/frontend/api.calls.json
@@ -1,0 +1,844 @@
+{
+  "generatedAt": "2025-01-04T00:00:00Z",
+  "description": "Frontend API call inventory derived from manual review of src/lib/*.ts as of audit",
+  "endpoints": [
+    {
+      "source": "src/lib/formsApi.ts:52-78",
+      "name": "ensureCsrfToken",
+      "method": "GET",
+      "path": "/api/security/csrf-token",
+      "base": "VITE_API_BASE_URL || window.location.origin",
+      "query": {},
+      "headers": [
+        "X-Requested-With: XMLHttpRequest"
+      ],
+      "credentials": "include",
+      "body": null,
+      "response": {
+        "200": {
+          "shape": {
+            "csrfToken": "string"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/formsApi.ts:97-131",
+      "name": "submitMedicalRecordRequest",
+      "method": "POST",
+      "path": "/api/forms/medical-record-request",
+      "base": "VITE_API_BASE_URL || window.location.origin",
+      "query": {},
+      "headers": [
+        "X-Requested-With: XMLHttpRequest",
+        "X-CSRF-Token: <cached token>"
+      ],
+      "credentials": "include",
+      "body": {
+        "type": "multipart/form-data",
+        "fields": {
+          "full_name": {
+            "type": "string",
+            "required": true
+          },
+          "hn": {
+            "type": "string",
+            "required": true
+          },
+          "citizen_id": {
+            "type": "string",
+            "required": true
+          },
+          "phone": {
+            "type": "string",
+            "required": true
+          },
+          "email": {
+            "type": "string",
+            "required": true
+          },
+          "address": {
+            "type": "string",
+            "required": true
+          },
+          "reason": {
+            "type": "string",
+            "required": true
+          },
+          "consent": {
+            "type": "string",
+            "required": true,
+            "note": "Sent as '1' or '0'"
+          },
+          "idcard_file": {
+            "type": "file",
+            "required": false
+          }
+        }
+      },
+      "response": {
+        "201": {
+          "shape": {
+            "ok": "boolean",
+            "id": "string",
+            "message": "string"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/formsApi.ts:133-160",
+      "name": "submitDonation",
+      "method": "POST",
+      "path": "/api/forms/donation",
+      "base": "VITE_API_BASE_URL || window.location.origin",
+      "query": {},
+      "headers": [
+        "Content-Type: application/json",
+        "X-Requested-With: XMLHttpRequest",
+        "X-CSRF-Token: <cached token>"
+      ],
+      "credentials": "include",
+      "body": {
+        "type": "json",
+        "fields": {
+          "donor_name": {
+            "type": "string",
+            "required": true
+          },
+          "amount": {
+            "type": "number",
+            "required": true
+          },
+          "channel": {
+            "type": "string",
+            "required": true
+          },
+          "phone": {
+            "type": "string",
+            "required": true
+          },
+          "email": {
+            "type": "string",
+            "required": true
+          },
+          "note": {
+            "type": "string",
+            "required": false
+          }
+        }
+      },
+      "response": {
+        "201": {
+          "shape": {
+            "ok": "boolean",
+            "id": "string",
+            "message": "string"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/formsApi.ts:162-182",
+      "name": "submitSatisfactionSurvey",
+      "method": "POST",
+      "path": "/api/forms/satisfaction",
+      "base": "VITE_API_BASE_URL || window.location.origin",
+      "query": {},
+      "headers": [
+        "Content-Type: application/json",
+        "X-Requested-With: XMLHttpRequest",
+        "X-CSRF-Token: <cached token>"
+      ],
+      "credentials": "include",
+      "body": {
+        "type": "json",
+        "fields": {
+          "score_overall": {
+            "type": "number",
+            "required": true
+          },
+          "score_waittime": {
+            "type": "number",
+            "required": true
+          },
+          "score_staff": {
+            "type": "number",
+            "required": true
+          },
+          "comment": {
+            "type": "string",
+            "required": false
+          },
+          "service_date": {
+            "type": "string",
+            "required": true
+          }
+        }
+      },
+      "response": {
+        "201": {
+          "shape": {
+            "ok": "boolean",
+            "id": "string",
+            "message": "string"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/formsApi.ts:184-211",
+      "name": "submitHealthRiderApplication",
+      "method": "POST",
+      "path": "/api/programs/health-rider/apply",
+      "base": "VITE_API_BASE_URL || window.location.origin",
+      "query": {},
+      "headers": [
+        "Content-Type: application/json",
+        "X-Requested-With: XMLHttpRequest",
+        "X-CSRF-Token: <cached token>"
+      ],
+      "credentials": "include",
+      "body": {
+        "type": "json",
+        "fields": {
+          "full_name": {
+            "type": "string",
+            "required": true
+          },
+          "hn": {
+            "type": "string",
+            "required": true
+          },
+          "address": {
+            "type": "string",
+            "required": true
+          },
+          "district": {
+            "type": "string",
+            "required": true
+          },
+          "province": {
+            "type": "string",
+            "required": true
+          },
+          "zipcode": {
+            "type": "string",
+            "required": true
+          },
+          "phone": {
+            "type": "string",
+            "required": true
+          },
+          "line_id": {
+            "type": "string",
+            "required": false
+          },
+          "consent": {
+            "type": "boolean",
+            "required": true
+          }
+        }
+      },
+      "response": {
+        "201": {
+          "shape": {
+            "ok": "boolean",
+            "id": "string",
+            "message": "string"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/api.ts:244-278",
+      "name": "fetchNews",
+      "method": "GET",
+      "path": "/news",
+      "base": "VITE_PUBLIC_API || 'http://localhost:4000/api'",
+      "query": {},
+      "headers": [],
+      "credentials": "omit",
+      "body": null,
+      "response": {
+        "200": {
+          "shape": {
+            "news": [
+              {
+                "id": "string",
+                "title": "string",
+                "summary": "string",
+                "content": "string",
+                "publishedAt": "string",
+                "imageUrl": "string",
+                "isFeatured": "boolean",
+                "displayOrder": "number"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:32-47",
+      "name": "ensureCsrfToken",
+      "method": "GET",
+      "path": "/security/csrf-token",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "query": {},
+      "headers": [],
+      "credentials": "include",
+      "body": null,
+      "response": {
+        "200": {
+          "shape": {
+            "csrfToken": "string"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:64-76",
+      "name": "login",
+      "method": "POST",
+      "path": "/auth/login",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "query": {},
+      "headers": [
+        "Content-Type: application/json",
+        "X-CSRF-Token: <cached token>"
+      ],
+      "credentials": "include",
+      "body": {
+        "type": "json",
+        "fields": {
+          "username": {
+            "type": "string",
+            "required": true
+          },
+          "password": {
+            "type": "string",
+            "required": true
+          },
+          "acceptPolicies": {
+            "type": "boolean",
+            "required": true
+          },
+          "rememberMe": {
+            "type": "boolean",
+            "required": true
+          }
+        }
+      },
+      "response": {
+        "200": {
+          "shape": {
+            "accessToken": "string",
+            "refreshToken": "string",
+            "user": {
+              "id": "string",
+              "username": "string",
+              "role": "string",
+              "acceptedPolicies": "boolean",
+              "cid": "string|null",
+              "fullName": "string",
+              "department": "string|null",
+              "lastLoginAt": "string|null"
+            }
+          }
+        },
+        "401": {
+          "shape": {
+            "message": "string"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:77-86",
+      "name": "refresh",
+      "method": "POST",
+      "path": "/auth/refresh",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "query": {},
+      "headers": [
+        "Content-Type: application/json",
+        "X-CSRF-Token: <cached token>"
+      ],
+      "credentials": "include",
+      "body": {
+        "type": "json",
+        "fields": {
+          "refreshToken": {
+            "type": "string",
+            "required": true
+          }
+        }
+      },
+      "response": {
+        "200": {
+          "shape": {
+            "accessToken": "string",
+            "refreshToken": "string",
+            "user": "AuthenticatedUser"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:87-98",
+      "name": "logout",
+      "method": "POST",
+      "path": "/auth/logout",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "query": {},
+      "headers": [
+        "Content-Type: application/json",
+        "Authorization: Bearer <accessToken?>",
+        "X-CSRF-Token: <cached token>"
+      ],
+      "credentials": "include",
+      "body": {
+        "type": "json",
+        "fields": {
+          "refreshToken": {
+            "type": "string",
+            "required": false
+          }
+        }
+      },
+      "response": {
+        "200": {
+          "shape": {}
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:99-112",
+      "name": "fetchDoctorPatients",
+      "method": "GET",
+      "path": "/doctor/patients",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [
+        "Authorization: Bearer <accessToken>"
+      ],
+      "credentials": "include",
+      "query": {},
+      "body": null,
+      "response": {
+        "200": {
+          "shape": {
+            "patients": [
+              {
+                "id": "string",
+                "name": "string",
+                "diagnosis": "string",
+                "updatedAt": "string"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:113-121",
+      "name": "fetchNurseSchedules",
+      "method": "GET",
+      "path": "/nurse/schedules",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [
+        "Authorization: Bearer <accessToken>"
+      ],
+      "credentials": "include",
+      "query": {},
+      "body": null,
+      "response": {
+        "200": {
+          "shape": {
+            "schedules": [
+              {
+                "id": "string",
+                "shiftDate": "string",
+                "shiftType": "string"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:122-131",
+      "name": "fetchStaffNews",
+      "method": "GET",
+      "path": "/staff/news",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [
+        "Authorization: Bearer <accessToken>"
+      ],
+      "credentials": "include",
+      "query": {},
+      "body": null,
+      "response": {
+        "200": {
+          "shape": {
+            "news": [
+              {
+                "id": "string",
+                "title": "string",
+                "content": "string",
+                "publishedAt": "string"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:132-142",
+      "name": "listAllNews",
+      "method": "GET",
+      "path": "/news",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [
+        "Authorization: Bearer <accessToken>"
+      ],
+      "credentials": "include",
+      "query": {},
+      "body": null,
+      "response": {
+        "200": {
+          "shape": {
+            "news": "NewsItem[]"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:143-152",
+      "name": "createNews",
+      "method": "POST",
+      "path": "/news",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [
+        "Authorization: Bearer <accessToken>",
+        "Content-Type: application/json",
+        "X-CSRF-Token: <cached token>"
+      ],
+      "credentials": "include",
+      "body": {
+        "type": "json",
+        "fields": {
+          "title": {
+            "type": "string",
+            "required": true
+          },
+          "summary": {
+            "type": "string",
+            "required": true
+          },
+          "content": {
+            "type": "string",
+            "required": true
+          },
+          "imageUrl": {
+            "type": "string",
+            "required": true
+          },
+          "publishedAt": {
+            "type": "string",
+            "required": false
+          },
+          "isFeatured": {
+            "type": "boolean",
+            "required": false
+          },
+          "displayOrder": {
+            "type": "number",
+            "required": false
+          }
+        }
+      },
+      "response": {
+        "201": {
+          "shape": {
+            "news": "NewsItem"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:153-164",
+      "name": "updateNews",
+      "method": "PUT",
+      "path": "/news/{id}",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [
+        "Authorization: Bearer <accessToken>",
+        "Content-Type: application/json",
+        "X-CSRF-Token: <cached token>"
+      ],
+      "credentials": "include",
+      "body": {
+        "type": "json",
+        "fields": {
+          "title": {
+            "type": "string",
+            "required": false
+          },
+          "summary": {
+            "type": "string",
+            "required": false
+          },
+          "content": {
+            "type": "string",
+            "required": false
+          },
+          "imageUrl": {
+            "type": "string",
+            "required": false
+          },
+          "publishedAt": {
+            "type": "string",
+            "required": false
+          },
+          "isFeatured": {
+            "type": "boolean",
+            "required": false
+          },
+          "displayOrder": {
+            "type": "number",
+            "required": false
+          }
+        }
+      },
+      "response": {
+        "200": {
+          "shape": {
+            "news": "NewsItem"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:165-173",
+      "name": "deleteNews",
+      "method": "DELETE",
+      "path": "/news/{id}",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [
+        "Authorization: Bearer <accessToken>",
+        "X-CSRF-Token: <cached token>"
+      ],
+      "credentials": "include",
+      "body": null,
+      "response": {
+        "204": {
+          "shape": null
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:174-180",
+      "name": "listUsers",
+      "method": "GET",
+      "path": "/users",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [
+        "Authorization: Bearer <accessToken>"
+      ],
+      "credentials": "include",
+      "query": {},
+      "body": null,
+      "response": {
+        "200": {
+          "shape": {
+            "users": "AuthenticatedUser[]"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:181-190",
+      "name": "createUser",
+      "method": "POST",
+      "path": "/users",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [
+        "Authorization: Bearer <accessToken>",
+        "Content-Type: application/json",
+        "X-CSRF-Token: <cached token>"
+      ],
+      "credentials": "include",
+      "body": {
+        "type": "json",
+        "fields": {
+          "username": {
+            "type": "string",
+            "required": true
+          },
+          "password": {
+            "type": "string",
+            "required": true
+          },
+          "role": {
+            "type": "string",
+            "required": true
+          }
+        }
+      },
+      "response": {
+        "201": {
+          "shape": {
+            "user": "AuthenticatedUser"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:191-200",
+      "name": "updateUser",
+      "method": "PUT",
+      "path": "/users/{id}",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [
+        "Authorization: Bearer <accessToken>",
+        "Content-Type: application/json",
+        "X-CSRF-Token: <cached token>"
+      ],
+      "credentials": "include",
+      "body": {
+        "type": "json",
+        "fields": {
+          "password": {
+            "type": "string",
+            "required": false
+          },
+          "role": {
+            "type": "string",
+            "required": false
+          },
+          "acceptedPolicies": {
+            "type": "boolean",
+            "required": false
+          }
+        }
+      },
+      "response": {
+        "200": {
+          "shape": {
+            "user": "AuthenticatedUser"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:201-204",
+      "name": "deleteUser",
+      "method": "DELETE",
+      "path": "/users/{id}",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [
+        "Authorization: Bearer <accessToken>",
+        "X-CSRF-Token: <cached token>"
+      ],
+      "credentials": "include",
+      "body": null,
+      "response": {
+        "204": {
+          "shape": null
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:205-213",
+      "name": "listAuditLogs",
+      "method": "GET",
+      "path": "/users/logs/audit",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [
+        "Authorization: Bearer <accessToken>"
+      ],
+      "credentials": "include",
+      "query": {},
+      "body": null,
+      "response": {
+        "200": {
+          "shape": {
+            "logs": [
+              {
+                "id": "string",
+                "action": "string",
+                "ip": "string|null",
+                "createdAt": "string",
+                "username": "string|null"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:214-222",
+      "name": "deleteAccount",
+      "method": "DELETE",
+      "path": "/account",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [
+        "Authorization: Bearer <accessToken>",
+        "Content-Type: application/json",
+        "X-CSRF-Token: <cached token>"
+      ],
+      "credentials": "include",
+      "body": {
+        "type": "json",
+        "fields": {
+          "password": {
+            "type": "string",
+            "required": true
+          }
+        }
+      },
+      "response": {
+        "200": {
+          "shape": {}
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:223-227",
+      "name": "fetchPrivacyPolicy",
+      "method": "GET",
+      "path": "/policies/privacy",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [],
+      "credentials": "include",
+      "query": {},
+      "body": null,
+      "response": {
+        "200": {
+          "shape": {
+            "policy": "string"
+          }
+        }
+      }
+    },
+    {
+      "source": "src/lib/secureApi.ts:228-231",
+      "name": "fetchTerms",
+      "method": "GET",
+      "path": "/policies/terms",
+      "base": "VITE_SECURE_API || 'http://localhost:4000/api'",
+      "headers": [],
+      "credentials": "include",
+      "query": {},
+      "body": null,
+      "response": {
+        "200": {
+          "shape": {
+            "terms": "string"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest",
-    "lint": "echo 'add eslint later'"
+    "lint": "echo 'add eslint later'",
+    "integrate:check": "tsc -p ../tools/integration-check/tsconfig.json && node ../tools/integration-check/dist/index.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",

--- a/reports/auth_rbac_flow.md
+++ b/reports/auth_rbac_flow.md
@@ -1,0 +1,38 @@
+# Auth & RBAC Flow Audit
+
+## Implementation snapshot
+- `AuthContext` เรียก `secureApi.login` แล้วบันทึก `accessToken`, `refreshToken`, `user` ลง `sessionStorage` โดยไม่เรียก `/api/staff/me` ตามสัญญาหลังเข้าสู่ระบบ 【F:frontend/src/context/AuthContext.tsx†L16-L86】【F:docs/ROUTES.md†L126-L158】
+- `secureApi.login` คาดหวัง response เป็น `{ accessToken, refreshToken, user }` ซึ่งต่างจากรูปแบบ `{ data: { token, user }, meta }` ที่เอกสารกำหนด และไม่อ่าน abilities จาก token 【F:frontend/src/lib/secureApi.ts†L60-L80】【F:docs/ROUTES.md†L160-L187】
+- การ refresh token (`secureApi.refresh`) ส่ง `POST /auth/refresh` แต่เอกสารไม่มี endpoint ดังกล่าว ทำให้ flow เสี่ยงล้มเหลวเมื่อเชื่อมกับ API จริง 【F:frontend/src/lib/secureApi.ts†L77-L86】【F:docs/ROUTES.md†L160-L214】
+- เส้นทาง `/dashboard` ไม่ได้ห่อด้วย `RequireAuth` (เพียงตรวจสอบในคอมโพเนนต์) ทำให้ผู้ใช้ไม่ล็อกอินยังเข้าถึงหน้าได้ แม้ UI จะแสดงข้อความแจ้ง แต่ resource ภายในจะยังเรียก API โดยไม่มี token 【F:frontend/src/router.tsx†L63-L88】【F:frontend/src/pages/dashboard/Dashboard.tsx†L1-L110】
+- RBAC ตรวจสอบด้วย `user.role` เท่านั้น ไม่ได้อิง `abilities` ตามที่เอกสาร `SECURITY.md` ระบุ ส่งผลให้ token ที่มี ability ไม่ตรง role อาจผ่านการป้องกัน 【F:frontend/src/router.tsx†L34-L63】【F:docs/SECURITY.md†L11-L20】
+
+## Mermaid sequence (ตามโค้ดปัจจุบัน)
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant FE as Frontend (AuthContext)
+    participant API as Backend API
+
+    U->>FE: submit username/password
+    FE->>API: POST /auth/login { username, password, acceptPolicies, rememberMe }
+    API-->>FE: 200 { accessToken, refreshToken, user }
+    FE->>FE: store tokens & user in sessionStorage
+    Note over FE: ไม่เรียก GET /api/staff/me
+    FE-->>U: redirect/dashboard (ไม่ตรวจ abilities)
+    U->>FE: access /dashboard
+    FE->>FE: ตรวจ state ใน component (ไม่มี route guard)
+    FE->>API: เรียก endpoint ตาม role โดยแนบ Bearer token
+```
+
+## ช่องว่างสำคัญ
+1. **Response shape mismatch** – ต้องปรับฝั่ง frontend ให้แปลง `{ data: { token, user } }` จาก backend ไม่ใช่ `{ accessToken, ... }`
+2. **ไม่มีการ verify ด้วย `/api/staff/me`** – ไม่ตรง `docs/ROUTES.md` และขาดการ sync abilities/role ล่าสุด
+3. **Route guard ไม่ครอบคลุม** – ควรใช้ `RequireAuth` กับ `/dashboard` และหน้าภายในทั้งหมดเพื่อกัน unauthenticated access
+4. **ไม่มีการจัดการ 401/403 ตามเอกสาร** – `secureApi` ขว้าง `Error(message)` ที่ไม่ตรงกับ payload `{ error: { message } }` ทำให้ UX ไม่ทราบสถานะจริง 【F:frontend/src/lib/secureApi.ts†L41-L90】【F:docs/ROUTES.md†L214-L240】
+
+## คำแนะนำการแก้ไขฝั่ง Front
+- ปรับ `secureApi.request` ให้ map response จาก `{ data, meta }` และโยน error จาก `error.message`
+- เรียก `GET /api/staff/me` หลัง login/refresh เพื่อตรวจ role + abilities ล่าสุดก่อน render dashboard
+- ใช้ `RequireAuth` ครอบ `/dashboard` และเส้นทาง intranet ทั้งหมด พร้อม redirect ไปหน้า login เมื่อรับ 401/419
+- เพิ่ม logic ตรวจสอบ ability (`user.abilities.includes('admin')`) ตาม Security policy ไม่ใช่แค่ role string

--- a/reports/csrf_forms_checklist.md
+++ b/reports/csrf_forms_checklist.md
@@ -1,0 +1,13 @@
+# CSRF Forms Checklist
+
+| Form | Token retrieval | Submission headers | Notes | Status |
+| --- | --- | --- | --- | --- |
+| Medical record request | เรียก `GET /api/security/csrf-token` แต่คาดหวัง body เป็น `{ csrfToken }` ทำให้พังกับ payload จริง `{ data: { csrf_token } }` | ตั้ง `X-Requested-With`, `X-CSRF-Token` (ไม่มี `Accept: application/json`) | ไม่มีการ validate ไฟล์ตาม policy และส่ง `consent` เป็น string `1/0` | ❌
+| Donation form | ใช้ `ensureCsrfToken` เดียวกัน (token shape ผิด) | ส่ง `Content-Type: application/json`, `X-Requested-With`, `X-CSRF-Token` แต่ยังขาด `Accept` | บังคับ `email`, `phone` เป็น required ทั้งที่ optional และไม่ handle error shape | ❌
+| Satisfaction survey | ใช้ `ensureCsrfToken` (shape ผิด) | เช่นเดียวกับด้านบน | บังคับ `service_date` เป็น required ขัดสัญญา | ❌
+| Health rider apply | ใช้ `ensureCsrfToken` (shape ผิด) | ตั้ง header JSON เหมือนฟอร์มอื่น | บังคับ `hn` เป็น required (เอกสาร optional) | ❌
+
+## Observations
+- แม้จะเรียก endpoint token ก่อน submit แต่การอ่านค่า `csrfToken` แทน `data.csrf_token` ทำให้ header `X-CSRF-Token` ว่าง/null กับ API จริง 【F:frontend/src/lib/formsApi.ts†L52-L78】
+- ไม่ตั้ง `Accept: application/json` ทำให้ fallback error ของ Laravel เป็น HTML; `parseError` จะไม่พบบอดี้ `error` ตามมาตรฐาน 【F:frontend/src/lib/formsApi.ts†L80-L124】【F:docs/ROUTES.md†L5-L8】
+- ขาดการจัดการ cookie `XSRF-TOKEN` (ไม่มีการตรวจว่าตั้งค่าได้หรือไม่) หากโดเมนไม่อยู่ใน `SANCTUM_STATEFUL_DOMAINS` จะล้มเหลวตาม `docs/SECURITY.md` 【F:docs/SECURITY.md†L9-L28】

--- a/reports/env_integration.md
+++ b/reports/env_integration.md
@@ -1,0 +1,18 @@
+# ENV & CORS Integration Review
+
+## Base URL usage
+- ฟอร์มสาธารณะ (`formsApi`) ใช้ `VITE_API_BASE_URL` หากไม่ตั้งค่าจะ fallback เป็น `window.location.origin` ซึ่งเสี่ยง mismatch กับโดเมน API จริง และไม่ครอบคลุมกรณี SSR หรือสคริปต์รันนอกเบราว์เซอร์ 【F:frontend/src/lib/formsApi.ts†L40-L56】
+- พื้นที่ staff (`secureApi`) ใช้ `VITE_SECURE_API` แต่ตั้งค่า default เป็น `http://localhost:4000/api` ที่ไม่ตรงกับข้อเสนอในเอกสาร (`http://localhost:8000`) และไม่แบ่ง staging/prod ตาม `docs/ENV.md` 【F:frontend/src/lib/secureApi.ts†L28-L35】【F:docs/ENV.md†L38-L58】
+- คอนเทนต์ข่าวสาธารณะ (`api.fetchNews`) ใช้ `VITE_PUBLIC_API` แต่ fallback เป็น `http://localhost:4000/api` เช่นเดียวกัน ส่งผลให้ดึงข้อมูลจาก mock service ไม่ตรง API จริงเมื่อไม่ตั้งค่า ENV 【F:frontend/src/lib/api.ts†L46-L75】【F:frontend/src/lib/api.ts†L244-L278】
+
+## Credentials & CORS
+- ทุกคำขอของ `formsApi` และ `secureApi` ตั้ง `credentials: 'include'` เพื่อใช้ cookie/CSRF ซึ่งสอดคล้องกับนโยบาย Sanctum แต่ต้องแน่ใจว่า `SANCTUM_STATEFUL_DOMAINS` ฝั่ง backend ครอบคลุมโดเมน frontend ตาม `docs/ENV.md` 【F:frontend/src/lib/formsApi.ts†L58-L76】【F:frontend/src/lib/secureApi.ts†L33-L80】【F:docs/ENV.md†L52-L58】
+- ยังไม่มีการตั้ง header `Accept` เป็น `application/json` ตามข้อกำหนดใน `docs/ROUTES.md` สำหรับคำขอที่เปลี่ยนข้อมูล ทำให้ Laravel อาจส่ง HTML error กลับมาและทำให้ parser ฝั่ง frontend ล้มเหลว 【F:docs/ROUTES.md†L5-L8】【F:frontend/src/lib/formsApi.ts†L90-L114】
+
+## แนะนำไฟล์ `.env.local`
+ตัวอย่างไฟล์ `.env.local.sample` ถูกเพิ่มไว้ที่ `frontend/.env.local.sample` ให้ copy ไปสร้าง `.env.local` แล้วแก้ค่าให้ตรงสภาพแวดล้อม 【F:frontend/.env.local.sample†L1-L6】
+
+## ช่องว่างที่ต้องแก้
+1. ปรับ default base URL ให้ตรงกับ `docs/ENV.md` และสนับสนุน staging/prod ผ่าน `.env`
+2. เพิ่มการตั้งค่า `Accept: application/json` ทุกคำขอที่เปลี่ยนข้อมูลตามนโยบาย Laravel
+3. จัดทำคู่มือ mapping ระหว่างโดเมน frontend ↔ `SANCTUM_STATEFUL_DOMAINS` ใน README เพื่อเลี่ยงปัญหา cookie ไม่ถูกตั้ง

--- a/reports/error_handling_matrix.md
+++ b/reports/error_handling_matrix.md
@@ -1,0 +1,15 @@
+# Error Handling Matrix
+
+| Endpoint group | Expected status codes (docs) | Frontend behaviour | Assessment |
+| --- | --- | --- | --- |
+| Public forms (`/api/forms/*`, `/api/programs/health-rider/apply`) | 201 success, 400 validation, 419 CSRF, 429 rate limit, 500 server 【F:docs/ROUTES.md†L72-L188】 | `formsApi` โยน `FormApiError` ที่ดึง `message` และ `errors` จากบอดี้ราบ (ไม่ใช่ `error.message`). เมื่อ backend ส่ง `{ error: { message } }` จะไม่เจอข้อความและ fallback เป็น "ไม่สามารถส่งข้อมูลได้"; ไม่มีการจับ 429/419 แยก | ❌ ไม่ตรง schema และไม่มี UX เฉพาะสถานะสำคัญ 【F:frontend/src/lib/formsApi.ts†L80-L124】 |
+| CSRF token (`GET /api/security/csrf-token`) | 200/429/500 【F:docs/ROUTES.md†L20-L46】 | หาก response ไม่ `ok` จะ throw `Error('ไม่สามารถดึง CSRF token ได้')` โดยไม่อ่านข้อความจาก body; ไม่ retry | ⚠️ ข้อความรวม generic แต่พอใช้งานได้ (ยังไม่อ่าน `error.message`) 【F:frontend/src/lib/formsApi.ts†L58-L78】 |
+| Auth login/logout | 200 success, 401 invalid, 429 limiter, 500 server 【F:docs/ROUTES.md†L160-L214】 | `secureApi.request` อ่าน `message` จาก root level (คาดว่า backend ส่ง `{ message }`); ถ้าไม่พบจะใช้ข้อความ default "เกิดข้อผิดพลาดในการเชื่อมต่อเซิร์ฟเวอร์"; ไม่จับ 429/419 เฉพาะ ก่อให้เกิด UX เดิม | ❌ Response shape mismatch ทำให้ 401/429 จาก backend กลายเป็น generic error 【F:frontend/src/lib/secureApi.ts†L41-L90】 |
+| Staff APIs (`/api/staff/news`, `/api/staff/me`) | 200 success, 401/403 auth, 429 limiter, 404 not found | ทุกคำขอใช้ `secureApi.request` เดียวกัน → กรณี 403/404 จะได้ข้อความ default ไม่ระบุปัญหา, ไม่มี redirect/log out เมื่อ 401 | ❌ ไม่มี fail-safe (เช่น logout เมื่อ token หมดอายุ) หรือข้อความระบุสิทธิ์ 【F:frontend/src/lib/secureApi.ts†L71-L137】 |
+| Public news (`GET /api/news`) | 200 success, 400 query invalid, 429 limiter, 500 server 【F:docs/ROUTES.md†L32-L70】 | หาก `fetch` ล้มเหลวหรือ status ≠ 200 จะ fallback dataset mock และ log `console.warn`; ผู้ใช้ไม่เห็น error | ⚠️ ไม่แจ้งผู้ใช้ แต่ยังมีคอนเทนต์สำรอง; เสี่ยงปิดบังปัญหา prod 【F:frontend/src/lib/api.ts†L260-L278】 |
+
+## ข้อเสนอปรับปรุง
+1. ปรับ parser ให้รองรับ payload `{ error: { message, details } }` และ map status → UX (แสดง field error, แจ้งให้ retry, สั่งรีเฟรช token ฯลฯ)
+2. เมื่อเจอ 401/419 จาก `secureApi` ให้ trigger logout/redirect หรือขอ CSRF token ใหม่ตาม `docs/SECURITY.md`
+3. แสดงข้อความเฉพาะสำหรับ 429 (rate limit) และ 403 (สิทธิ์ไม่พอ) แทน generic error เพื่อช่วยผู้ใช้
+4. สำหรับข่าวสาธารณะ ให้แจ้ง banner ว่า "ข้อมูลล่าสุดไม่สามารถดึงได้" แทน fallback เงียบ ๆ

--- a/reports/frontend_integration_summary.md
+++ b/reports/frontend_integration_summary.md
@@ -1,0 +1,38 @@
+# Frontend ↔ Backend Integration Summary
+
+## Executive summary
+- **สถานะรวม: ไม่ผ่าน** – frontend ปัจจุบันไม่สอดคล้องกับสัญญา API หลัก (news, forms, auth, staff) ทั้งในเรื่อง path, payload, header, และ error shape
+- **Coverage:**
+  - Path+method ที่พบใน frontend เทียบกับสัญญา = **5/14 (35.7%)** – อีก 9 endpoint ไม่ถูกเรียกเลย 【F:reports/route_contract_diff.md†L6-L18】
+  - เมื่อพิจารณา schema/header → ไม่มี endpoint ใดสอดคล้องครบถ้วน (5/5 mismatch) 【F:reports/route_contract_diff.md†L20-L66】
+- **Smoke test:** ทุกการทดลองยิง API ล้มเหลวเพราะ base URL/contract ไม่ตรง (0/3 สำเร็จ) 【F:reports/smoke_results.json†L1-L38】【a2bd33†L1-L6】
+
+## Checklist overview
+| Item | Status | หลักฐาน |
+| --- | --- | --- |
+| Auth & RBAC | ❌ | `reports/auth_rbac_flow.md` – ไม่มี `/api/staff/me`, shape login ผิด, route guard ไม่ครอบคลุม |
+| CSRF flow | ❌ | `reports/csrf_forms_checklist.md` – token shape ผิด, header ขาด `Accept`, optional field ถูกบังคับ |
+| Upload policy | ❌ | `reports/upload_policy_check.md` – ไม่ตรวจ MIME/EXT/ขนาด, consent เป็น string |
+| Rate limit / Error UX | ❌ | `reports/error_handling_matrix.md` – ไม่รองรับ 401/403/429 ตามเอกสาร |
+| Observability | ❌ | `reports/observability.md` – ไม่อ่าน/ส่ง `X-Request-Id`, log PII โดยตรง |
+| ENV & Base URL | ⚠️ | `reports/env_integration.md` – ต้องตั้งค่าเองผ่าน `.env.local`, default fallback ผิดโดเมน |
+
+## Key gaps (prioritized)
+1. **Critical – Auth contract mismatch:** ปรับ `secureApi` ให้สอดคล้องกับ response `{ data: { token, user }, meta }`, เรียก `/api/staff/me`, และใช้ abilities แทน role string 【F:reports/auth_rbac_flow.md†L3-L33】
+2. **Critical – Form submission schema:** แก้ header `Accept`, map error `{ error: { message } }`, และ align required/optional fields รวมถึง CSRF token shape 【F:reports/route_contract_diff.md†L24-L66】【F:reports/csrf_forms_checklist.md†L3-L12】
+3. **High – Endpoint path drift:** ปรับ path `/staff/news` ทั้งชุดให้ตรง `/api/staff/news` และลบ endpoint ที่ backend ไม่มี เช่น `/users`, `/account`, `/auth/refresh` 【F:reports/route_contract_diff.md†L20-L44】【F:reports/payload_contracts.md†L20-L32】
+4. **High – Upload validation:** เพิ่ม client-side MIME/size guard ตาม `docs/SECURITY.md` เพื่อลดภาระ backend และ UX ผิดพลาด 【F:reports/upload_policy_check.md†L3-L9】
+5. **Medium – Observability:** ดึง `X-Request-Id` จาก response และรวม log ให้ไม่เผย PII เพื่อรองรับ incident response 【F:reports/observability.md†L1-L13】
+6. **Medium – News fetch fallback:** แจ้งผู้ใช้เมื่อดึงข่าวไม่สำเร็จ แทน fallback เงียบ เพื่อให้ทีม monitor ปัญหาได้ทัน 【F:reports/payload_contracts.md†L6-L12】
+
+## Action items
+- [ ] ปรับ `formsApi`/`secureApi` ให้รองรับโครงสร้าง `{ data, meta }` และ error `{ error: { message, details } }`
+- [ ] เพิ่ม `Accept: application/json` และส่งค่า CSRF ตาม field `data.csrf_token`
+- [ ] แก้ routing + RBAC ให้ใช้ `RequireAuth` ครอบหน้า `/dashboard` และเช็ค `abilities`
+- [ ] เพิ่ม validation ฝั่ง client สำหรับไฟล์แนบ (MIME/ขนาด) และ optional field handling ตาม `docs/ROUTES.md`
+- [ ] ใช้ `X-Request-Id` ใน log/error message + เตรียม UI แสดงรหัสให้ผู้ใช้แจ้ง incident
+- [ ] อัปเดต `.env.local`/README ให้ชัดเจนเรื่อง base URL และ SANCTUM domains, แล้ว rerun `npm run integrate:check`
+
+## เอกสารอ้างอิง
+- Route diff & smoke test: `reports/route_contract_diff.md`, `reports/smoke_results.json`
+- การวิเคราะห์เชิงลึก: `reports/env_integration.md`, `reports/auth_rbac_flow.md`, `reports/csrf_forms_checklist.md`, `reports/payload_contracts.md`, `reports/error_handling_matrix.md`, `reports/upload_policy_check.md`, `reports/observability.md`

--- a/reports/observability.md
+++ b/reports/observability.md
@@ -1,0 +1,14 @@
+# Observability & Request ID Review
+
+## Request tracing
+- เอกสารกำหนดให้ backend แนบ `X-Request-Id` ทุกคำขอและให้ log ฝั่ง frontend ระบุ ID เมื่อส่ง error ต่อทีม SRE 【F:docs/SECURITY.md†L29-L38】
+- โค้ด frontend ไม่มีการอ่าน header `X-Request-Id` จาก response ใด ๆ (`fetch` ทุกตัวละทิ้ง header) และไม่ส่ง header ดังกล่าวเมื่อเรียกซ้ำ → tracing end-to-end ทำไม่ได้ 【F:frontend/src/lib/formsApi.ts†L75-L124】【F:frontend/src/lib/secureApi.ts†L41-L137】
+
+## Client-side logging
+- `api.fetchNews` และฟอร์มต่าง ๆ log ด้วย `console.info/warn` เพื่อ debug แต่ไม่ได้ระบุ request id หรือป้องกัน PII (เช่น log payload ทั้งก้อนใน console) 【F:frontend/src/lib/api.ts†L268-L278】【F:frontend/src/lib/api.ts†L286-L311】
+- ไม่มีการตั้งค่า log level หรือ wrapper รวมศูนย์ ทำให้การเก็บ log production ทำได้ยากและมีความเสี่ยงเปิดเผยข้อมูลใน DevTools
+
+## คำแนะนำ
+1. เขียน utility อ่าน header `X-Request-Id` จากทุก response แล้วผูกกับ error/log message ที่ส่งให้ผู้ใช้/ทีม incident
+2. เมื่อยิง request ซ้ำ (retry) ให้ส่ง header `X-Request-Id` เดิมหรือแนบใน body เพื่อช่วยทีม backend correlate
+3. ลดการ log payload ที่มี PII ใน console; หากจำเป็นต้อง debug ให้ mask ข้อมูลสำคัญก่อน log

--- a/reports/payload_contracts.md
+++ b/reports/payload_contracts.md
@@ -1,0 +1,28 @@
+# Payload Contract Verification
+
+## สรุปจากการอ่านโค้ด frontend
+
+### Public content
+- `api.fetchNews` เรียก `GET {PUBLIC_API}/news` และคาดหวัง payload `{ news: [...] }` โดยไม่อ่าน `data.pagination` หรือ `meta` ทำให้ไม่รองรับรูปแบบ `{ data: { news, pagination }, meta }` ตามเอกสาร และไม่ส่งพารามิเตอร์ `page/per_page/sort` 【F:frontend/src/lib/api.ts†L244-L278】【F:docs/ROUTES.md†L32-L70】
+- เมื่อ response ไม่ตรง (`response.ok === false`) จะ fallback เป็น dataset ในตัว ไม่ alert ผู้ใช้ว่า API ล้มเหลว ส่งผลให้ error ถูกซ่อน 【F:frontend/src/lib/api.ts†L260-L278】
+
+### Public forms
+- Medical record request: แปลง `consent` เป็น string `1/0` และบังคับ `email`, `reason` เป็น required ต่างจาก contract ที่ optional; ไม่แนบ metadata สำหรับไฟล์ตาม policy (MIME/size ไม่ตรวจ) 【F:frontend/src/lib/formsApi.ts†L97-L137】【F:docs/ROUTES.md†L72-L112】
+- Donation: ส่งค่า `note` เสมอ (default `''`) และบังคับ `phone`, `email` เป็น required ขัดกับ schema (`phone/email` optional) 【F:frontend/src/lib/formsApi.ts†L133-L160】【F:docs/ROUTES.md†L114-L142】
+- Satisfaction: บังคับ `service_date` และส่งทุก field แม้ optional, ไม่จัดการ timezone/format ตามสัญญาที่ระบุ `date` 【F:frontend/src/lib/formsApi.ts†L162-L182】【F:docs/ROUTES.md†L144-L170】
+- Health rider: บังคับ `hn` ทั้งที่ optional และส่ง `consent` เป็น boolean (ตรงสัญญา) แต่ไม่มี validation สำหรับ `zipcode` (ไม่ตรวจความยาว) 【F:frontend/src/lib/formsApi.ts†L184-L211】【F:docs/ROUTES.md†L172-L188】
+
+### Authentication & Staff APIs
+- `secureApi.request` สร้าง header `Content-Type: application/json` ทุกคำขอ ทำให้ `GET` ก็ใส่ header นี้ (ไม่จำเป็น) และไม่ตั้ง `Accept` 【F:frontend/src/lib/secureApi.ts†L41-L76】
+- Login/refresh/logout คาดหวัง shape `{ accessToken, refreshToken, user }`; เมื่อ backend ส่ง `{ data: { token, user } }` จะ throw error จาก `response.ok` แม้สถานะ 200 เพราะ `data.message` ไม่มี 【F:frontend/src/lib/secureApi.ts†L64-L98】【F:docs/ROUTES.md†L160-L214】
+- Staff news/doctor/nurse endpoint ทั้งหมดใช้ path `/news`, `/doctor/patients`, `/nurse/schedules` ต่างจาก contract `/api/staff/news` และไม่มี query pagination ทำให้ไม่รองรับ rate limit/filters ตามเอกสาร 【F:frontend/src/lib/secureApi.ts†L99-L173】【F:docs/ROUTES.md†L189-L228】
+- User management (`/users`, `/account`, `/users/logs/audit`) ไม่มีในสัญญา API ส่งผลให้ backend จริงตอบ 404/403 แน่นอน 【F:frontend/src/lib/secureApi.ts†L174-L222】【F:docs/ROUTES.md†L189-L228】
+
+## ตัวอย่างผลทดสอบอัตโนมัติ
+จาก `npm run integrate:check` (smoke test) มีเพียง 3 endpoint ที่พยายามยิง (`/api/health`, `/api/security/csrf-token`, `/api/news`) และทั้งหมดล้มเหลวเพราะ backend ไม่ตอบ/ไม่ตรง config; รายละเอียดอยู่ใน `reports/smoke_results.json` 【F:reports/smoke_results.json†L1-L38】【a2bd33†L1-L6】
+
+## คำแนะนำ
+1. ปรับโค้ดให้ map payload `{ data, meta }` ทุก endpoint และรองรับ `error` object ตามมาตรฐาน Laravel
+2. เพิ่มการตรวจ/แปลงค่า form ตาม schema (optional vs required, boolean vs string, validation สำหรับไฟล์และ zipcode)
+3. Sync path/method กับสัญญา (`/api/staff/news` เป็นต้น) และลบ endpoint ที่ backend ไม่มี (users/logs/account) หรือย้ายไป feature roadmap
+4. ใช้ smoke script ที่เพิ่ม cookie jar/CSRF flow เพื่อจับ error จริงหลังแก้ไข

--- a/reports/route_contract_diff.md
+++ b/reports/route_contract_diff.md
@@ -1,0 +1,105 @@
+# Route Contract Diff Report
+
+- Missing endpoints: 9
+- Extra frontend-only endpoints: 19
+- Contract mismatches: 5
+
+## Endpoints missing from frontend implementation
+| Method | Path |
+| --- | --- |
+| GET | /api/health |
+| GET | /api/news |
+| POST | /api/auth/login |
+| POST | /api/auth/logout |
+| GET | /api/staff/me |
+| GET | /api/staff/news |
+| POST | /api/staff/news |
+| PUT | /api/staff/news/{id} |
+| DELETE | /api/staff/news/{id} |
+
+## Frontend endpoints without contract coverage
+| Method | Path | Source |
+| --- | --- | --- |
+| GET | /news | src/lib/secureApi.ts:132-142 |
+| GET | /security/csrf-token | src/lib/secureApi.ts:32-47 |
+| POST | /auth/login | src/lib/secureApi.ts:64-76 |
+| POST | /auth/refresh | src/lib/secureApi.ts:77-86 |
+| POST | /auth/logout | src/lib/secureApi.ts:87-98 |
+| GET | /doctor/patients | src/lib/secureApi.ts:99-112 |
+| GET | /nurse/schedules | src/lib/secureApi.ts:113-121 |
+| GET | /staff/news | src/lib/secureApi.ts:122-131 |
+| POST | /news | src/lib/secureApi.ts:143-152 |
+| PUT | /news/{id} | src/lib/secureApi.ts:153-164 |
+| DELETE | /news/{id} | src/lib/secureApi.ts:165-173 |
+| GET | /users | src/lib/secureApi.ts:174-180 |
+| POST | /users | src/lib/secureApi.ts:181-190 |
+| PUT | /users/{id} | src/lib/secureApi.ts:191-200 |
+| DELETE | /users/{id} | src/lib/secureApi.ts:201-204 |
+| GET | /users/logs/audit | src/lib/secureApi.ts:205-213 |
+| DELETE | /account | src/lib/secureApi.ts:214-222 |
+| GET | /policies/privacy | src/lib/secureApi.ts:223-227 |
+| GET | /policies/terms | src/lib/secureApi.ts:228-231 |
+
+## Contract mismatches (shape/header/schema differences)
+### GET /api/security/csrf-token
+- มี header เกินสัญญา `x-requested-with: xmlhttprequest`
+- รูปแบบ response 200 ไม่ตรง
+contract: {"shape":{"data":{"csrf_token":"string"},"meta":{"request_id":"string"}}}
+frontend: {"shape":{"csrfToken":"string"}}
+- frontend ไม่รองรับ response สถานะ 429
+- frontend ไม่รองรับ response สถานะ 500
+
+### POST /api/forms/medical-record-request
+- ขาด header บังคับ `accept: application/json`
+- ขาด header บังคับ `x-csrf-token`
+- มี header เกินสัญญา `x-csrf-token: <cached token>`
+- เงื่อนไข required ของ `email` ไม่ตรง (contract=false, frontend=true)
+- เงื่อนไข required ของ `reason` ไม่ตรง (contract=false, frontend=true)
+- ชนิดข้อมูลของ `consent` ไม่ตรง (contract=boolean, frontend=string)
+- รูปแบบ response 201 ไม่ตรง
+contract: {"shape":{"data":{"id":"number","submitted_at":"string"},"meta":{"request_id":"string"}}}
+frontend: {"shape":{"id":"string","message":"string","ok":"boolean"}}
+- frontend ไม่รองรับ response สถานะ 400
+- frontend ไม่รองรับ response สถานะ 419
+- frontend ไม่รองรับ response สถานะ 429
+- frontend ไม่รองรับ response สถานะ 500
+
+### POST /api/forms/donation
+- ขาด header บังคับ `accept: application/json`
+- ขาด header บังคับ `x-csrf-token`
+- มี header เกินสัญญา `x-csrf-token: <cached token>`
+- เงื่อนไข required ของ `phone` ไม่ตรง (contract=false, frontend=true)
+- เงื่อนไข required ของ `email` ไม่ตรง (contract=false, frontend=true)
+- รูปแบบ response 201 ไม่ตรง
+contract: {"shape":{"data":{"id":"number","reference_code":"string","submitted_at":"string"},"meta":{"request_id":"string"}}}
+frontend: {"shape":{"id":"string","message":"string","ok":"boolean"}}
+- frontend ไม่รองรับ response สถานะ 400
+- frontend ไม่รองรับ response สถานะ 419
+- frontend ไม่รองรับ response สถานะ 429
+- frontend ไม่รองรับ response สถานะ 500
+
+### POST /api/forms/satisfaction
+- ขาด header บังคับ `accept: application/json`
+- ขาด header บังคับ `x-csrf-token`
+- มี header เกินสัญญา `x-csrf-token: <cached token>`
+- เงื่อนไข required ของ `service_date` ไม่ตรง (contract=false, frontend=true)
+- รูปแบบ response 201 ไม่ตรง
+contract: {"shape":{"data":{"id":"number","submitted_at":"string"},"meta":{"request_id":"string"}}}
+frontend: {"shape":{"id":"string","message":"string","ok":"boolean"}}
+- frontend ไม่รองรับ response สถานะ 400
+- frontend ไม่รองรับ response สถานะ 419
+- frontend ไม่รองรับ response สถานะ 429
+- frontend ไม่รองรับ response สถานะ 500
+
+### POST /api/programs/health-rider/apply
+- ขาด header บังคับ `accept: application/json`
+- ขาด header บังคับ `x-csrf-token`
+- มี header เกินสัญญา `x-csrf-token: <cached token>`
+- เงื่อนไข required ของ `hn` ไม่ตรง (contract=false, frontend=true)
+- รูปแบบ response 201 ไม่ตรง
+contract: {"shape":{"data":{"id":"number","submitted_at":"string"},"meta":{"request_id":"string"}}}
+frontend: {"shape":{"id":"string","message":"string","ok":"boolean"}}
+- frontend ไม่รองรับ response สถานะ 400
+- frontend ไม่รองรับ response สถานะ 419
+- frontend ไม่รองรับ response สถานะ 429
+- frontend ไม่รองรับ response สถานะ 500

--- a/reports/smoke_results.json
+++ b/reports/smoke_results.json
@@ -1,0 +1,135 @@
+{
+  "generatedAt": "2025-10-03T17:00:22.776Z",
+  "baseUrl": "http://localhost:8000",
+  "results": [
+    {
+      "method": "GET",
+      "path": "/api/health",
+      "category": "public",
+      "attempted": true,
+      "ok": false,
+      "detail": "fetch failed",
+      "startedAt": "2025-10-03T17:00:22.716Z",
+      "completedAt": "2025-10-03T17:00:22.772Z"
+    },
+    {
+      "method": "GET",
+      "path": "/api/security/csrf-token",
+      "category": "public",
+      "attempted": true,
+      "ok": false,
+      "detail": "fetch failed",
+      "startedAt": "2025-10-03T17:00:22.772Z",
+      "completedAt": "2025-10-03T17:00:22.774Z"
+    },
+    {
+      "method": "GET",
+      "path": "/api/news",
+      "category": "public",
+      "attempted": true,
+      "ok": false,
+      "detail": "fetch failed",
+      "startedAt": "2025-10-03T17:00:22.774Z",
+      "completedAt": "2025-10-03T17:00:22.776Z"
+    },
+    {
+      "method": "POST",
+      "path": "/api/forms/medical-record-request",
+      "category": "public-form",
+      "attempted": false,
+      "ok": false,
+      "detail": "requires CSRF cookie + human consent; skipped to avoid unintended submissions",
+      "startedAt": "2025-10-03T17:00:22.776Z"
+    },
+    {
+      "method": "POST",
+      "path": "/api/forms/donation",
+      "category": "public-form",
+      "attempted": false,
+      "ok": false,
+      "detail": "requires CSRF cookie + human consent; skipped to avoid unintended submissions",
+      "startedAt": "2025-10-03T17:00:22.776Z"
+    },
+    {
+      "method": "POST",
+      "path": "/api/forms/satisfaction",
+      "category": "public-form",
+      "attempted": false,
+      "ok": false,
+      "detail": "requires CSRF cookie + human consent; skipped to avoid unintended submissions",
+      "startedAt": "2025-10-03T17:00:22.776Z"
+    },
+    {
+      "method": "POST",
+      "path": "/api/programs/health-rider/apply",
+      "category": "public-form",
+      "attempted": false,
+      "ok": false,
+      "detail": "requires CSRF cookie + human consent; skipped to avoid unintended submissions",
+      "startedAt": "2025-10-03T17:00:22.776Z"
+    },
+    {
+      "method": "POST",
+      "path": "/api/auth/login",
+      "category": "auth",
+      "attempted": false,
+      "ok": false,
+      "detail": "requires authenticated staff token which is not configured in smoke test",
+      "startedAt": "2025-10-03T17:00:22.776Z"
+    },
+    {
+      "method": "POST",
+      "path": "/api/auth/logout",
+      "category": "auth",
+      "attempted": false,
+      "ok": false,
+      "detail": "requires authenticated staff token which is not configured in smoke test",
+      "startedAt": "2025-10-03T17:00:22.776Z"
+    },
+    {
+      "method": "GET",
+      "path": "/api/staff/me",
+      "category": "staff",
+      "attempted": false,
+      "ok": false,
+      "detail": "requires authenticated staff token which is not configured in smoke test",
+      "startedAt": "2025-10-03T17:00:22.776Z"
+    },
+    {
+      "method": "GET",
+      "path": "/api/staff/news",
+      "category": "staff",
+      "attempted": false,
+      "ok": false,
+      "detail": "requires authenticated staff token which is not configured in smoke test",
+      "startedAt": "2025-10-03T17:00:22.776Z"
+    },
+    {
+      "method": "POST",
+      "path": "/api/staff/news",
+      "category": "staff",
+      "attempted": false,
+      "ok": false,
+      "detail": "requires authenticated staff token which is not configured in smoke test",
+      "startedAt": "2025-10-03T17:00:22.776Z"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/staff/news/{id}",
+      "category": "staff",
+      "attempted": false,
+      "ok": false,
+      "detail": "requires authenticated staff token which is not configured in smoke test",
+      "startedAt": "2025-10-03T17:00:22.776Z"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/staff/news/{id}",
+      "category": "staff",
+      "attempted": false,
+      "ok": false,
+      "detail": "requires authenticated staff token which is not configured in smoke test",
+      "startedAt": "2025-10-03T17:00:22.776Z"
+    }
+  ]
+}

--- a/reports/upload_policy_check.md
+++ b/reports/upload_policy_check.md
@@ -1,0 +1,12 @@
+# Upload Policy Check
+
+| Requirement (docs) | Implementation | Observation | Status |
+| --- | --- | --- | --- |
+| รองรับไฟล์เฉพาะแบบฟอร์ม `medical-record-request` พร้อมตรวจ MIME, EXT, ขนาด ≤ `FORM_UPLOAD_MAX_MB` 【F:docs/SECURITY.md†L21-L36】【F:docs/ENV.md†L46-L60】 | `formsApi.submitMedicalRecordRequest` แนบไฟล์ตรง ๆ ใน `FormData` โดยไม่ตรวจ MIME/ขนาด หรือ whitelist ส่วนขยาย | เสี่ยงอัปโหลดไฟล์ต้องห้ามไปยัง backend (ภาระ validation ทั้งหมดตกที่ backend) | ❌ |
+| ส่งค่า `consent` เป็น boolean/true ตามข้อกำหนด PDPA | Frontend ส่ง string `1/0` ใน FormData | Laravel จะรับเป็น truthy/falsey แต่อ่านง่ายน้อยลง และไม่ตรง contract | ⚠️ |
+| Sanitise ข้อมูลก่อน log | ฟังก์ชัน log (`console.info`) สำหรับฟอร์ม appointment/contact เท่านั้น ไม่มีการ log payload ของฟอร์มที่ยิง backend | ไม่มีการ log PII แต่ควรยืนยันว่าฝั่ง backend log ตาม policy | ✅ (ไม่มี log เพิ่มเติม) |
+
+## ข้อเสนอแนะ
+1. เพิ่มการตรวจ MIME/extension/ขนาดที่ client ตามค่า `FORM_ALLOWED_MIME`, `FORM_ALLOWED_EXT`, `FORM_UPLOAD_MAX_MB`
+2. ปรับ `consent` ให้เป็น boolean ใน FormData (ใช้ `formData.append('consent', payload.consent ? 'true' : 'false')` หรือส่งผ่าน JSON)
+3. เพิ่ม feedback ให้ผู้ใช้เมื่อไฟล์ถูกปฏิเสธก่อนส่ง เพื่อประสบการณ์ใช้งานที่ดี

--- a/tools/integration-check/src/index.ts
+++ b/tools/integration-check/src/index.ts
@@ -1,0 +1,24 @@
+import path from 'node:path'
+import { generateRouteDiff } from './routeDiff'
+import { runSmokeTests } from './smoke'
+
+const projectRoot = path.resolve(__dirname, '../../..')
+
+async function main() {
+  console.log('Generating route contract diff...')
+  const diffResult = generateRouteDiff(projectRoot)
+  console.log('Missing endpoints:', diffResult.missing.length)
+  console.log('Extra endpoints:', diffResult.extra.length)
+  console.log('Mismatched endpoints:', diffResult.mismatched.length)
+
+  console.log('Running smoke tests against documented endpoints...')
+  const results = await runSmokeTests(projectRoot)
+  const attempted = results.filter((item) => item.attempted)
+  const successes = attempted.filter((item) => item.ok)
+  console.log(`Attempted ${attempted.length} endpoints, ${successes.length} succeeded.`)
+}
+
+main().catch((error) => {
+  console.error('Integration check failed:', error)
+  process.exitCode = 1
+})

--- a/tools/integration-check/src/routeDiff.ts
+++ b/tools/integration-check/src/routeDiff.ts
@@ -1,0 +1,256 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+export type ContractEndpoint = {
+  path: string
+  method: string
+  headers?: string[]
+  query?: Record<string, unknown>
+  body?: {
+    type: string
+    fields?: Record<string, { type?: string; required?: boolean; [key: string]: unknown }>
+  } | null
+  responses?: Record<string, unknown>
+  errors?: Record<string, unknown>
+}
+
+export type FrontendEndpoint = {
+  path: string
+  method: string
+  headers?: string[]
+  query?: Record<string, unknown>
+  body?: {
+    type: string
+    fields?: Record<string, { type?: string; required?: boolean; [key: string]: unknown }>
+  } | null
+  responses?: Record<string, unknown>
+  response?: Record<string, unknown>
+}
+
+export type RouteDiffResult = {
+  missing: Array<{ method: string; path: string }>
+  extra: Array<{ method: string; path: string; source?: string }>
+  mismatched: Array<{
+    method: string
+    path: string
+    issues: string[]
+  }>
+}
+
+const normalizeHeaders = (headers?: string[]): string[] => {
+  if (!headers) return []
+  return headers.map((header) => header.toLowerCase()).sort()
+}
+
+const stableStringify = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return 'null'
+  }
+  if (typeof value !== 'object') {
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`
+  }
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b))
+  return `{${entries.map(([key, val]) => `${JSON.stringify(key)}:${stableStringify(val)}`).join(',')}}`
+}
+
+const compareFields = (
+  contractFields: Record<string, { type?: string; required?: boolean }> | undefined,
+  frontendFields: Record<string, { type?: string; required?: boolean }> | undefined
+): string[] => {
+  const issues: string[] = []
+  const contractKeys = new Set(Object.keys(contractFields ?? {}))
+  const frontendKeys = new Set(Object.keys(frontendFields ?? {}))
+
+  for (const key of contractKeys) {
+    if (!frontendKeys.has(key)) {
+      issues.push(`ขาด field \`${key}\` ตามสัญญา`)
+      continue
+    }
+    const c = contractFields?.[key] ?? {}
+    const f = frontendFields?.[key] ?? {}
+    if (Boolean(c.required) !== Boolean(f.required)) {
+      issues.push(`เงื่อนไข required ของ \`${key}\` ไม่ตรง (contract=${Boolean(c.required)}, frontend=${Boolean(f.required)})`)
+    }
+    if ((c.type ?? '').toLowerCase() !== (f.type ?? '').toLowerCase()) {
+      issues.push(`ชนิดข้อมูลของ \`${key}\` ไม่ตรง (contract=${c.type}, frontend=${f.type})`)
+    }
+  }
+
+  for (const key of frontendKeys) {
+    if (!contractKeys.has(key)) {
+      issues.push(`frontend ส่ง field เกินสัญญา \`${key}\``)
+    }
+  }
+
+  return issues
+}
+
+const compareBodies = (
+  contractBody: ContractEndpoint['body'],
+  frontendBody: FrontendEndpoint['body']
+): string[] => {
+  const issues: string[] = []
+  if (!contractBody && !frontendBody) {
+    return issues
+  }
+  if (!contractBody && frontendBody) {
+    issues.push('contract ไม่ต้องมี body แต่ frontend ส่ง body')
+    return issues
+  }
+  if (contractBody && !frontendBody) {
+    issues.push('contract บังคับ body แต่ frontend ไม่ส่ง')
+    return issues
+  }
+  if (!contractBody || !frontendBody) {
+    return issues
+  }
+
+  if ((contractBody.type ?? '').toLowerCase() !== (frontendBody.type ?? '').toLowerCase()) {
+    issues.push(`ชนิด body ไม่ตรง (contract=${contractBody.type}, frontend=${frontendBody.type})`)
+  }
+
+  issues.push(...compareFields(contractBody.fields, frontendBody.fields))
+
+  return issues
+}
+
+const compareResponses = (
+  contractResponses: Record<string, unknown> | undefined,
+  frontendResponses: Record<string, unknown> | undefined
+): string[] => {
+  const issues: string[] = []
+  const contractStatuses = new Set(Object.keys(contractResponses ?? {}))
+  const frontendStatuses = new Set(Object.keys(frontendResponses ?? {}))
+
+  for (const status of contractStatuses) {
+    if (!frontendStatuses.has(status)) {
+      issues.push(`frontend ไม่รองรับ response สถานะ ${status}`)
+      continue
+    }
+    const contractShape = stableStringify(contractResponses?.[status])
+    const frontendShape = stableStringify(frontendResponses?.[status])
+    if (contractShape !== frontendShape) {
+      issues.push(`รูปแบบ response ${status} ไม่ตรง\ncontract: ${contractShape}\nfrontend: ${frontendShape}`)
+    }
+  }
+
+  for (const status of frontendStatuses) {
+    if (!contractStatuses.has(status)) {
+      issues.push(`frontend คาดหวังสถานะ ${status} ที่ไม่อยู่ในสัญญา`)
+    }
+  }
+
+  return issues
+}
+
+export const generateRouteDiff = (projectRoot: string): RouteDiffResult => {
+  const contractPath = path.join(projectRoot, 'docs/api.contract.json')
+  const frontendPath = path.join(projectRoot, 'frontend/api.calls.json')
+  const contractRaw = JSON.parse(fs.readFileSync(contractPath, 'utf8')) as { endpoints: ContractEndpoint[] }
+  const frontendRaw = JSON.parse(fs.readFileSync(frontendPath, 'utf8')) as { endpoints: FrontendEndpoint[] }
+
+  const contractMap = new Map<string, ContractEndpoint>()
+  for (const endpoint of contractRaw.endpoints) {
+    contractMap.set(`${endpoint.method.toUpperCase()} ${endpoint.path}`, endpoint)
+  }
+
+  const frontendMap = new Map<string, FrontendEndpoint>()
+  for (const endpoint of frontendRaw.endpoints) {
+    const normalized: FrontendEndpoint = {
+      ...endpoint,
+      responses: endpoint.responses ?? endpoint.response
+    }
+    frontendMap.set(`${normalized.method.toUpperCase()} ${normalized.path}`, normalized)
+  }
+
+  const missing: RouteDiffResult['missing'] = []
+  const mismatched: RouteDiffResult['mismatched'] = []
+
+  for (const [key, contractEndpoint] of contractMap.entries()) {
+    if (!frontendMap.has(key)) {
+      missing.push({ method: contractEndpoint.method.toUpperCase(), path: contractEndpoint.path })
+      continue
+    }
+    const frontendEndpoint = frontendMap.get(key)!
+    const issues: string[] = []
+
+    const contractHeaders = normalizeHeaders(contractEndpoint.headers)
+    const frontendHeaders = normalizeHeaders(frontendEndpoint.headers)
+    const headerDiff = [
+      ...contractHeaders.filter((item) => !frontendHeaders.includes(item)).map((item) => `ขาด header บังคับ \`${item}\``),
+      ...frontendHeaders.filter((item) => !contractHeaders.includes(item)).map((item) => `มี header เกินสัญญา \`${item}\``)
+    ]
+    issues.push(...headerDiff)
+
+    issues.push(...compareBodies(contractEndpoint.body, frontendEndpoint.body))
+
+    issues.push(...compareResponses(contractEndpoint.responses, frontendEndpoint.responses))
+
+    const errorIssues = compareResponses(contractEndpoint.errors as Record<string, unknown> | undefined, undefined)
+    if (errorIssues.length > 0) {
+      issues.push(...errorIssues)
+    }
+
+    if (issues.length > 0) {
+      mismatched.push({ method: contractEndpoint.method.toUpperCase(), path: contractEndpoint.path, issues })
+    }
+  }
+
+  const extra: RouteDiffResult['extra'] = []
+  for (const [key, frontendEndpoint] of frontendMap.entries()) {
+    if (!contractMap.has(key)) {
+      extra.push({
+        method: frontendEndpoint.method.toUpperCase(),
+        path: frontendEndpoint.path,
+        source: frontendEndpoint['source']
+      })
+    }
+  }
+
+  const reportPath = path.join(projectRoot, 'reports/route_contract_diff.md')
+  const lines: string[] = []
+  lines.push('# Route Contract Diff Report')
+  lines.push('')
+  lines.push(`- Missing endpoints: ${missing.length}`)
+  lines.push(`- Extra frontend-only endpoints: ${extra.length}`)
+  lines.push(`- Contract mismatches: ${mismatched.length}`)
+  lines.push('')
+
+  if (missing.length > 0) {
+    lines.push('## Endpoints missing from frontend implementation')
+    lines.push('| Method | Path |')
+    lines.push('| --- | --- |')
+    for (const item of missing) {
+      lines.push(`| ${item.method} | ${item.path} |`)
+    }
+    lines.push('')
+  }
+
+  if (extra.length > 0) {
+    lines.push('## Frontend endpoints without contract coverage')
+    lines.push('| Method | Path | Source |')
+    lines.push('| --- | --- | --- |')
+    for (const item of extra) {
+      lines.push(`| ${item.method} | ${item.path} | ${item.source ?? ''} |`)
+    }
+    lines.push('')
+  }
+
+  if (mismatched.length > 0) {
+    lines.push('## Contract mismatches (shape/header/schema differences)')
+    for (const item of mismatched) {
+      lines.push(`### ${item.method} ${item.path}`)
+      for (const issue of item.issues) {
+        lines.push(`- ${issue}`)
+      }
+      lines.push('')
+    }
+  }
+
+  fs.writeFileSync(reportPath, lines.join('\n'))
+
+  return { missing, extra, mismatched }
+}

--- a/tools/integration-check/src/smoke.ts
+++ b/tools/integration-check/src/smoke.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+export type SmokeResult = {
+  method: string
+  path: string
+  category?: string
+  attempted: boolean
+  status?: number
+  ok: boolean
+  detail?: string
+  startedAt: string
+  completedAt?: string
+}
+
+type ContractFile = {
+  endpoints: Array<{
+    path: string
+    method: string
+    category?: string
+  }>
+}
+
+type EnvMap = Record<string, string>
+
+const parseEnvFile = (filePath: string): EnvMap => {
+  if (!fs.existsSync(filePath)) {
+    return {}
+  }
+  const result: EnvMap = {}
+  const content = fs.readFileSync(filePath, 'utf8')
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue
+    }
+    const [key, ...rest] = trimmed.split('=')
+    const value = rest.join('=')
+    if (key) {
+      result[key.trim()] = value?.trim()?.replace(/^"|"$/g, '') ?? ''
+    }
+  }
+  return result
+}
+
+const resolveBaseUrl = (projectRoot: string): string => {
+  const envFromProcess: EnvMap = {}
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value === 'string') {
+      envFromProcess[key] = value
+    }
+  }
+  const envFromFile = parseEnvFile(path.join(projectRoot, 'frontend/.env.local'))
+  const merged = { ...envFromFile, ...envFromProcess }
+  const base = merged.VITE_API_BASE_URL || merged.INTEGRATION_BASE_URL || 'http://localhost:8000'
+  return base.replace(/\/$/, '')
+}
+
+const shouldSkip = (category?: string, method?: string): string | null => {
+  if (!category) {
+    return null
+  }
+  if (category.startsWith('staff') || category === 'auth') {
+    return 'requires authenticated staff token which is not configured in smoke test'
+  }
+  if (category === 'public-form' && method && method.toUpperCase() !== 'GET') {
+    return 'requires CSRF cookie + human consent; skipped to avoid unintended submissions'
+  }
+  return null
+}
+
+export const runSmokeTests = async (projectRoot: string): Promise<SmokeResult[]> => {
+  const contractPath = path.join(projectRoot, 'docs/api.contract.json')
+  const contract = JSON.parse(fs.readFileSync(contractPath, 'utf8')) as ContractFile
+  const baseUrl = resolveBaseUrl(projectRoot)
+
+  const results: SmokeResult[] = []
+
+  for (const endpoint of contract.endpoints) {
+    const method = endpoint.method.toUpperCase()
+    const startedAt = new Date().toISOString()
+    const skipReason = shouldSkip(endpoint.category, method)
+    if (skipReason) {
+      results.push({
+        method,
+        path: endpoint.path,
+        category: endpoint.category,
+        attempted: false,
+        ok: false,
+        detail: skipReason,
+        startedAt
+      })
+      continue
+    }
+
+    const url = `${baseUrl}${endpoint.path}`
+    const headers: Record<string, string> = {
+      Accept: 'application/json'
+    }
+
+    const init: RequestInit = {
+      method,
+      headers
+    }
+
+    let ok = false
+    let status: number | undefined
+    let detail: string | undefined
+    try {
+      const response = await fetch(url, init)
+      status = response.status
+      ok = response.ok
+      detail = `Response status ${response.status}`
+    } catch (error) {
+      detail = error instanceof Error ? error.message : String(error)
+    }
+
+    results.push({
+      method,
+      path: endpoint.path,
+      category: endpoint.category,
+      attempted: true,
+      ok,
+      status,
+      detail,
+      startedAt,
+      completedAt: new Date().toISOString()
+    })
+  }
+
+  const outputPath = path.join(projectRoot, 'reports/smoke_results.json')
+  fs.writeFileSync(outputPath, JSON.stringify({
+    generatedAt: new Date().toISOString(),
+    baseUrl,
+    results
+  }, null, 2))
+
+  return results
+}

--- a/tools/integration-check/tsconfig.json
+++ b/tools/integration-check/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "typeRoots": ["../../frontend/node_modules/@types"],
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- derive and store the documented API contract plus the frontend call inventory for automated diffing
- add TypeScript integration-check tooling to build the contract diff report and smoke-test summary
- document environment setup and deliver a full suite of audit reports covering env/auth/CSRF/payload/error/upload/observability

## Testing
- npm run integrate:check

------
https://chatgpt.com/codex/tasks/task_e_68dfff66a9d0832ba7a15a59d88d4042